### PR TITLE
Replace ```for(node of nodes)``` usage with traditional array traversing

### DIFF
--- a/src/guidelines.js
+++ b/src/guidelines.js
@@ -245,7 +245,8 @@ module.exports = function (opts, cy, $, debounce) {
 			var minNode = nodes[0], min = lines.getDims(minNode)[type]["center"];
 			var maxNode = nodes[0], max = lines.getDims(maxNode)[type]["center"];
 
-			for (node of nodes){
+			for (var i = 0; i < nodes.length; i++){
+				var node = nodes[i];
 				if (lines.getDims(node)[type]["center"] < min){
 					min = lines.getDims(node)[type]["center"]; minNode = node;
 				}
@@ -273,14 +274,16 @@ module.exports = function (opts, cy, $, debounce) {
 		// Find nodes in range and check if they align
 		HTree.forEach(function(key, nodes){
 
-			for (left of nodes){
+			for (var i = 0; i < nodes.length; i++){
+				var left = nodes[i];
 				var leftDim = lines.getDims(left);
 				if (Math.abs(leftDim["vertical"]["center"] - nodeDim["vertical"]["center"]) < options.guidelinesStyle.range*cy.zoom()){
 					if ((leftDim["horizontal"]["right"]) == key && 
 						nodeDim["horizontal"]["left"] - leftDim["horizontal"]["right"] > options.guidelinesStyle.minDistRange){
 							var ripo = Math.round(2*Xcenter)-key;
 							HTree.forEach(function($, rightNodes){
-								for (right of rightNodes){
+								for (var j = 0; j < rightNodes.length; j++){
+									var right = rightNodes[j];
 									if (Math.abs(lines.getDims(right)["vertical"]["center"] - Ycenter) < options.guidelinesStyle.range*cy.zoom()){
 										if (Math.abs(ripo - lines.getDims(right)["horizontal"]["left"]) < 2*options.guidelinesTolerance){
 											leftNode = left; rightNode = right;
@@ -386,7 +389,8 @@ module.exports = function (opts, cy, $, debounce) {
 		// Find nodes in range and check if they align
 		VTree.forEach(function(key, nodes){
 
-			for (below of nodes){
+			for (var i = 0; i < nodes.length; i++){
+				var below = nodes[i];
 				var belowDim = lines.getDims(below);
 				if (Math.abs(belowDim["horizontal"]["center"] - nodeDim["horizontal"]["center"]) < options.guidelinesStyle.range*cy.zoom()){
 					if (belowDim["vertical"]["bottom"] == key &&
@@ -394,7 +398,8 @@ module.exports = function (opts, cy, $, debounce) {
 							var abpo = Math.round((2*Ycenter)-key);
 							VTree.forEach(function($, aboveNodes){
 								//if (aboveNodes){
-								for (above of aboveNodes){
+								for (var j = 0; j < aboveNodes.length; j++){
+									var above = aboveNodes[j];
 									if (Math.abs(lines.getDims(above)["horizontal"]["center"] - Xcenter) < options.guidelinesStyle.range*cy.zoom()){
 										if (Math.abs(abpo - lines.getDims(above)["vertical"]["top"]) < 2*options.guidelinesTolerance){
 											belowNode = below; aboveNode = above;
@@ -519,7 +524,8 @@ module.exports = function (opts, cy, $, debounce) {
 
 			// find the closest alignment in range of tolerance
 			Tree.forEach(function (exKey, nodes) {
-				for (n of nodes){
+				for (var i = 0; i < nodes.length; i++){
+					var n = nodes[i];
 					if (options.centerToEdgeAlignment || (dimKey != "center" && n.renderedPosition(otherAxis) != exKey) || (dimKey == "center" && n.renderedPosition(otherAxis) == exKey)){
 					var dif = Math.abs(center - n.renderedPosition(axis));
 					if ( dif < targetKey && dif < options.guidelinesStyle.geometricGuidelineRange*cy.zoom()){
@@ -581,14 +587,16 @@ module.exports = function (opts, cy, $, debounce) {
 
 		// Find nodes in range and check if they align
 		HTree.forEach(function(key, nodes){
-			for (left of nodes){
+			for (var i = 0; i < nodes.length; i++){
+				var left = nodes[i];
 				var leftDim = lines.getDims(left);
 				if (Math.abs(leftDim["vertical"]["center"] - nodeDim["vertical"]["center"]) < options.guidelinesStyle.range*cy.zoom()){
 					if ((leftDim["horizontal"][otherSide]) == key && 
 						compare[type](leftDim["horizontal"][otherSide], nodeDim["horizontal"][side])){
 							var ll = leftDim["horizontal"][side]-(nodeDim["horizontal"][side] - key);
 							HTree.forEach(function($, rightNodes){
-								for (right of rightNodes){
+								for (var j = 0; j < rightNodes.length; j++){
+									var right = rightNodes[j];
 									if (Math.abs(lines.getDims(right)["vertical"]["center"] - Ycenter) < options.guidelinesStyle.range*cy.zoom()){
 										if (Math.abs(ll - lines.getDims(right)["horizontal"][otherSide]) < 2*options.guidelinesTolerance){
 											leftNode = left; rightNode = right;
@@ -711,15 +719,16 @@ module.exports = function (opts, cy, $, debounce) {
 		}
 		// Find nodes in range and check if they align
 		VTree.forEach(function(key, nodes){
-
-			for (below of nodes){
+			for (var i = 0; i < nodes.length; i++){
+				var below = nodes[i];
 				var belowDim = lines.getDims(below);
 				if (Math.abs(belowDim["horizontal"]["center"] - nodeDim["horizontal"]["center"]) < options.guidelinesStyle.range*cy.zoom()){
 					if (belowDim["vertical"][otherSide] == key &&
 						compare[type](belowDim["vertical"][otherSide], nodeDim["vertical"][side])){
 							var ll = belowDim["vertical"][side]-(nodeDim["vertical"][side]-key);
 							VTree.forEach(function($, aboveNodes){
-								for (above of aboveNodes){
+								for (var j = 0; j < aboveNodes.length; j++){
+									var above = aboveNodes[j];
 									if (Math.abs(lines.getDims(above)["horizontal"]["center"] - Xcenter) < options.guidelinesStyle.range*cy.zoom()){
 										if (Math.abs(ll - lines.getDims(above)["vertical"][otherSide]) < 2*options.guidelinesTolerance){
 											belowNode = below; aboveNode = above;


### PR DESCRIPTION
I am working on automating the tests of CWC. The tests are written in ```qunit``` and I use ```node-qunit-phantomjs``` to make the html file dedicated for testing runnable through the command line. 

However, it was problematic in sbgnviz.js and this extension. I found out that the problem for sbgnviz.js is caused by a basic syntax error and I fixed it with the following commit (https://github.com/iVis-at-Bilkent/sbgnviz.js/commit/68784540b0afb89653bc088fa0f9bb85696fb144) and attached the commit to a PR in sbgnviz. 

The problem with this repository is related to usage of ```for(node of nodes)``` syntax. I am not sure but most probably it would be working for many of modern browsers. However, it is problematic in this case. 

This PR proposes to replace the usage of ```for ... of``` with traditional for loops.