### PR TITLE
Fixes multiple instances issue

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -1,5 +1,5 @@
-module.exports = function (cytoscape, cy,  $) {
-    
+module.exports = function (cytoscape, cy,  $, apiRegistered) {
+
     // Needed because parent nodes cannot be moved!
     function moveTopDown(node, dx, dy) {
         var nodes = node.union(node.descendants());
@@ -40,50 +40,58 @@ module.exports = function (cytoscape, cy,  $) {
     }
 
 
-    cytoscape( "collection", "align", function (horizontal, vertical, alignTo) {
+    // If extension api functions are not registed to cytoscape yet register them here.
+		// Note that ideally these functions should not be directly registered to core from cytoscape.js
+		// extensions
+    if ( !apiRegistered ) {
 
-        var eles = getTopMostNodes(this.nodes(":visible"));
+      cytoscape( "collection", "align", function (horizontal, vertical, alignTo) {
 
-        var modelNode = alignTo ? alignTo : eles[0];
+          var eles = getTopMostNodes(this.nodes(":visible"));
 
-        eles = eles.not(modelNode);
+          var modelNode = alignTo ? alignTo : eles[0];
 
-        horizontal = horizontal ? horizontal : "none";
-        vertical = vertical ? vertical : "none";
+          eles = eles.not(modelNode);
 
-
-        // 0 for center
-        var xFactor = 0;
-        var yFactor = 0;
-
-        if (vertical == "left")
-            xFactor = -1;
-        else if (vertical == "right")
-            xFactor = 1;
-
-        if (horizontal == "top")
-            yFactor = -1;
-        else if (horizontal == "bottom")
-            yFactor = 1;
+          horizontal = horizontal ? horizontal : "none";
+          vertical = vertical ? vertical : "none";
 
 
-        for (var i = 0; i < eles.length; i++) {
-            var node = eles[i];
-            var oldPos = $.extend({}, node.position());
-            var newPos = $.extend({}, node.position());
+          // 0 for center
+          var xFactor = 0;
+          var yFactor = 0;
 
-            if (vertical != "none")
-                newPos.x = modelNode.position("x") + xFactor * (modelNode.outerWidth() - node.outerWidth()) / 2;
+          if (vertical == "left")
+              xFactor = -1;
+          else if (vertical == "right")
+              xFactor = 1;
+
+          if (horizontal == "top")
+              yFactor = -1;
+          else if (horizontal == "bottom")
+              yFactor = 1;
 
 
-            if (horizontal != "none")
-                newPos.y = modelNode.position("y") + yFactor * (modelNode.outerHeight() - node.outerHeight()) / 2;
+          for (var i = 0; i < eles.length; i++) {
+              var node = eles[i];
+              var oldPos = $.extend({}, node.position());
+              var newPos = $.extend({}, node.position());
 
-            moveTopDown(node, newPos.x - oldPos.x, newPos.y - oldPos.y);
-        }
+              if (vertical != "none")
+                  newPos.x = modelNode.position("x") + xFactor * (modelNode.outerWidth() - node.outerWidth()) / 2;
 
-        return this;
-    });
+
+              if (horizontal != "none")
+                  newPos.y = modelNode.position("y") + yFactor * (modelNode.outerHeight() - node.outerHeight()) / 2;
+
+              moveTopDown(node, newPos.x - oldPos.x, newPos.y - oldPos.y);
+          }
+
+          return this;
+      });
+
+    }
+
 
     if (cy.undoRedo) {
         function getNodePositions() {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,11 @@
 
 		if( !cytoscape ){ return; } // can't register if cytoscape unspecified
 
+		// flag that indicates if extension api functions are registed to cytoscape
+		// note that ideally these functions should not be directly registered to core from cytoscape.js
+		// extensions
+		var apiRegistered = false;
+
 		var defaults = {
 			// On/Off Modules
 			/* From the following four snap options, at most one should be true at a given time */
@@ -90,7 +95,10 @@
 
 				eventsController = _eventsController(cy, snap, resize, snapToGridDuringDrag, drawGrid, guidelines, parentPadding, $, options);
 
-				alignment = _alignment(cytoscape, cy, $);
+				alignment = _alignment(cytoscape, cy, $, apiRegistered);
+
+				// mark that api functions are registered to cytoscape
+				apiRegistered = true;
 
 				eventsController.init(options);
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 
 		if( !cytoscape ){ return; } // can't register if cytoscape unspecified
 
-		var options = {
+		var defaults = {
 			// On/Off Modules
 			/* From the following four snap options, at most one should be true at a given time */
 			snapToGridOnRelease: true, // Snap to grid on release
@@ -67,10 +67,15 @@
 
 		cytoscape( 'core', 'gridGuide', function(opts){
 			var cy = this;
-			$.extend(true, options, opts);
 
 			// access the scratch pad for cy
 			var scratchPad = getScratch(cy);
+
+			// extend the already existing options for the instance or the default options
+			var options = $.extend(true, {}, scratchPad.options || defaults, opts);
+
+			// reset the options for the instance
+			scratchPad.options = options;
 
 			if (!scratchPad.initialized) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,6 @@
 		var _parentPadding = require("./parentPadding");
 		var _alignment = require("./alignment");
 		var debounce = require("./debounce");
-		var snap, resize, snapToGridDuringDrag, drawGrid, eventsController, guidelines, parentPadding, alignment;
 
 		function getScratch(cy) {
 			if (!cy.scratch("_gridGuide")) {
@@ -70,7 +69,13 @@
 			var cy = this;
 			$.extend(true, options, opts);
 
-			if (!getScratch(cy).initialized) {
+			// access the scratch pad for cy
+			var scratchPad = getScratch(cy);
+
+			if (!scratchPad.initialized) {
+
+				var snap, resize, snapToGridDuringDrag, drawGrid, eventsController, guidelines, parentPadding, alignment;
+
 				snap = _snapOnRelease(cy, options.gridSpacing);
 				resize = _resize(options.gridSpacing);
 				snapToGridDuringDrag = _snapToGridDuringDrag(cy, snap);
@@ -83,9 +88,15 @@
 				alignment = _alignment(cytoscape, cy, $);
 
 				eventsController.init(options);
-				getScratch(cy).initialized = true;
-			} else
+
+				// init params in scratchPad
+				scratchPad.initialized = true;
+				scratchPad.eventsController = eventsController;
+			}
+			else {
+				var eventsController = scratchPad.eventsController;
 				eventsController.syncWithOptions(options);
+			}
 
 			return this; // chainability
 		} ) ;


### PR DESCRIPTION
While working with multiple Cytoscape.js instances the grids was always being updated for the instance which is created latest. 

For example imagine that we have two Cytoscape.js instances named as ```cy1``` and ```cy2``` where ```cy2``` is created later. If I toggle ```showGrid``` option for ```cy1``` the changes were seen at the container of ```cy2``` rather than container of ```cy1```.

This PR is created to solve this bug.